### PR TITLE
Added PasswordAuthenticator Logic to CassandraConnector

### DIFF
--- a/data/cassandra.go
+++ b/data/cassandra.go
@@ -48,9 +48,9 @@ func (f Filter) query() string {
 func NewCassandraConnector(path, port, keyspace, username,
 	password string) *CassandraConnector {
 	logger := util.LogInit()
-	logger.Printf("New Connector Path: %s, Port: %s, Keyspace: %s, "+
-		"Username: %s, Password: %s",
-		path, port, keyspace, username, password)
+	logger.Printf("New Connector Path: %s, Port: %s, Keyspace: %s, Username: %s",
+		path, port, keyspace, username)
+	logger.Debug("Using Password: " + password)
 	cluster := gocql.NewCluster(path)
 	cluster.Keyspace = keyspace
 	cluster.Consistency = gocql.Quorum

--- a/data/cassandra.go
+++ b/data/cassandra.go
@@ -18,6 +18,8 @@ type CassandraConnector struct {
 	path     string
 	port     string
 	keyspace string
+	username string
+	password string
 }
 
 type CassandraQueryOptions struct {
@@ -43,12 +45,19 @@ func (f Filter) query() string {
 	return queryString
 }
 
-func NewCassandraConnector(path, port, keyspace string) *CassandraConnector {
+func NewCassandraConnector(path, port, keyspace, username,
+	password string) *CassandraConnector {
 	logger := util.LogInit()
-	logger.Printf("New Connector Path: %s, Port: %s, Keyspace: %s", path, port, keyspace)
+	logger.Printf("New Connector Path: %s, Port: %s, Keyspace: %s, "+
+		"Username: %s, Password: %s",
+		path, port, keyspace, username, password)
 	cluster := gocql.NewCluster(path)
 	cluster.Keyspace = keyspace
 	cluster.Consistency = gocql.Quorum
+	cluster.Authenticator = gocql.PasswordAuthenticator{
+		Username: username,
+		Password: password,
+	}
 	session, err := cluster.CreateSession()
 	if err != nil {
 		logger.Panic(err)
@@ -57,14 +66,16 @@ func NewCassandraConnector(path, port, keyspace string) *CassandraConnector {
 		path:     path,
 		port:     port,
 		keyspace: keyspace,
+		username: username,
+		password: password,
 	}
 	cassConn.Session = session
 	cassConn.Logger = logger
 	return &cassConn
 }
 
-// NewCassandraQueryOptions creates a new options object.
 /*
+NewCassandraQueryOptions creates a new options object.
 key: query field name
 value: query value
 id: True if field is a UUID Cassandra key
@@ -76,8 +87,8 @@ func NewCassandraQueryOptions(key, value string, id bool) CassandraQueryOptions 
 	}
 }
 
-// AddFilter adds a filter to an CassandraQueryOptions object
 /*
+AddFilter adds a filter to an CassandraQueryOptions object
 key: query field name
 value: query value
 id: True if field is a UUID Cassandra key

--- a/make
+++ b/make
@@ -18,6 +18,8 @@ go test $(glide novendor)|| { echo "Tests failed" ; exit 1; }
 export CASSANDRA_URL='0.0.0.0'
 export CASSANDRA_PORT=''
 export CASSANDRA_KEYSPACE='skill_directory_keyspace'
+export CASSANDRA_USERNAME='cassandra'
+export CASSANDRA_PASSWORD='cassandra'
 
 # echo $CASSANDRA_URL
 # echo $CASSANDRA_KEYSPACE

--- a/router/router.go
+++ b/router/router.go
@@ -9,8 +9,9 @@ import (
 )
 
 /*
-Route contains an HTTP URI endpoint (e.g. "/skills" or "/skills/") in the 'path' var, and the
-handler function with which to handle HTTP requests to that endpoint in the 'handlerFunc' var.
+Route contains an HTTP URI endpoint (e.g. "/skills" or "/skills/") in the 'path'
+var, and the handler function with which to handle HTTP requests to that
+endpoint in the 'handlerFunc' var.
 */
 type Route struct {
 	path        string
@@ -31,6 +32,8 @@ var (
 	url      string
 	port     string
 	keyspace string
+	username string
+	password string
 	session  *data.CassandraConnector
 	routes   []Route
 )
@@ -40,7 +43,9 @@ func initializeCassandra() {
 	url = util.GetProperty("CASSANDRA_URL")
 	port = util.GetProperty("CASSANDRA_PORT")
 	keyspace = util.GetProperty("CASSANDRA_KEYSPACE")
-	session = data.NewCassandraConnector(url, port, keyspace)
+	username = util.GetProperty("CASSANDRA_USERNAME")
+	password = util.GetProperty("CASSANDRA_PASSWORD")
+	session = data.NewCassandraConnector(url, port, keyspace, username, password)
 }
 
 func loadRoutes() {
@@ -85,8 +90,9 @@ func loadRoutes() {
 }
 
 /*
-StartRouter() instantiates a new http.ServeMux and registers with it each endpoint that is currently being handled
-by the SkillDirectory REST API with an appropriate handler function for that endpoint. This http.ServeMux is returned.
+StartRouter() instantiates a new http.ServeMux and registers with it each
+endpoint that is currently being handled by the SkillDirectory REST API with an
+appropriate handler function for that endpoint. This http.ServeMux is returned.
 */
 func StartRouter() (mux *http.ServeMux) {
 	initializeCassandra()


### PR DESCRIPTION
Fixed #116. Note that the username and password specified in the `make` file don't actually affect anything, because the current docker image that we are using does not specify an authenticator in the `cassandra.yml` file (I don't believe our image even has that file at all): https://docs.datastax.com/en/cassandra/2.1/cassandra/security/security_config_native_authenticate_t.html