### PR TITLE
When skill is deleted attached links are also deleted

### DIFF
--- a/controller/linkscontroller.go
+++ b/controller/linkscontroller.go
@@ -90,8 +90,8 @@ func (c *LinksController) removeLink() error {
 		return errors.MissingIDError(fmt.Errorf("no Link ID specified in request URL"))
 	}
 
-	err := c.session.Delete("links", linkID, data.CassandraQueryOptions{})
-	//TODO: Add skillid field to opts
+	err := c.session.Delete("links", linkID, data.NewCassandraQueryOptions("skill_id", "", true))
+
 	if err != nil {
 		c.Printf("removeLink() failed for the following reason:\n\t%q\n", err)
 		return errors.NoSuchIDError(fmt.Errorf(

--- a/controller/linkscontroller.go
+++ b/controller/linkscontroller.go
@@ -90,7 +90,8 @@ func (c *LinksController) removeLink() error {
 		return errors.MissingIDError(fmt.Errorf("no Link ID specified in request URL"))
 	}
 
-	err := c.session.Delete("links", linkID, "skill_id")
+	err := c.session.Delete("links", linkID, data.CassandraQueryOptions{})
+	//TODO: Add skillid field to opts
 	if err != nil {
 		c.Printf("removeLink() failed for the following reason:\n\t%q\n", err)
 		return errors.NoSuchIDError(fmt.Errorf(

--- a/controller/skillreviewscontroller.go
+++ b/controller/skillreviewscontroller.go
@@ -82,7 +82,8 @@ func (c *SkillReviewsController) removeSkillReview() error {
 		return errors.MissingIDError(fmt.Errorf("no SkillReview ID in request URL"))
 	}
 
-	err := c.session.Delete("skillreviews", skillReviewID, "skill_id")
+	err := c.session.Delete("skillreviews", skillReviewID, data.CassandraQueryOptions{})
+	// TODO Add skillid field to opts
 	if err != nil {
 		log.Printf("removeSkillReview() failed for the following reason:"+
 			"\n\t%q\n", err)

--- a/controller/skillreviewscontroller.go
+++ b/controller/skillreviewscontroller.go
@@ -82,7 +82,7 @@ func (c *SkillReviewsController) removeSkillReview() error {
 		return errors.MissingIDError(fmt.Errorf("no SkillReview ID in request URL"))
 	}
 
-	err := c.session.Delete("skillreviews", skillReviewID, data.CassandraQueryOptions{})
+	err := c.session.Delete("skillreviews", skillReviewID, data.NewCassandraQueryOptions("skillsreviews", "", true))
 	// TODO Add skillid field to opts
 	if err != nil {
 		log.Printf("removeSkillReview() failed for the following reason:"+

--- a/controller/skillscontroller.go
+++ b/controller/skillscontroller.go
@@ -113,9 +113,13 @@ func (c *SkillsController) removeSkill() error {
 		return errors.MissingIDError(fmt.Errorf("no Skill ID in request URL"))
 	}
 	err1 := c.removeSkillChildren(skillID)
-	c.Printf("removingSkillChildren: %v", err1)
+	if err1 != nil {
+		c.Printf("removingSkillChildren: %v", err1)
+
+	}
+
 	err := c.session.Delete("skills", skillID, data.CassandraQueryOptions{})
-	//TODO Add skillid field to opts
+
 	if err != nil {
 		c.Printf("removeSkill() failed for the following reason:\n\t%q\n", err)
 		return errors.NoSuchIDError(fmt.Errorf(

--- a/controller/skillscontroller.go
+++ b/controller/skillscontroller.go
@@ -112,8 +112,10 @@ func (c *SkillsController) removeSkill() error {
 	if skillID == "" {
 		return errors.MissingIDError(fmt.Errorf("no Skill ID in request URL"))
 	}
-
-	err := c.session.Delete("skills", skillID)
+	err1 := c.removeSkillChildren(skillID)
+	c.Printf("removingSkillChildren: %v", err1)
+	err := c.session.Delete("skills", skillID, data.CassandraQueryOptions{})
+	//TODO Add skillid field to opts
 	if err != nil {
 		c.Printf("removeSkill() failed for the following reason:\n\t%q\n", err)
 		return errors.NoSuchIDError(fmt.Errorf(
@@ -122,6 +124,11 @@ func (c *SkillsController) removeSkill() error {
 
 	c.Printf("Skill Deleted with ID: %s", skillID)
 	return nil
+}
+
+func (c *SkillsController) removeSkillChildren(skillID string) error {
+	return c.session.Delete("links", "", data.NewCassandraQueryOptions("skill_ID", skillID, true))
+
 }
 
 func (c *SkillsController) addSkill() error {

--- a/controller/teammemberscontroller.go
+++ b/controller/teammemberscontroller.go
@@ -157,7 +157,7 @@ func (c *TeamMembersController) removeTeamMember() error {
 		return errors.MissingIDError(fmt.Errorf("no TeamMember ID in request URL"))
 	}
 
-	err := c.session.Delete("teammembers", teamMemberID)
+	err := c.session.Delete("teammembers", teamMemberID, data.CassandraQueryOptions{})
 	if err != nil {
 		c.Printf("removeTeamMember() failed for the following reason:\n\t%q\n", err)
 		return errors.NoSuchIDError(fmt.Errorf(

--- a/controller/teammemberscontroller_test.go
+++ b/controller/teammemberscontroller_test.go
@@ -145,6 +145,60 @@ func TestPostTeamMember_Error(t *testing.T) {
 	}
 }
 
+func TestPutTeamMember(t *testing.T) {
+	body := getReaderForNewTeamMember("1234", "John Smith", "Cabbage Plucker")
+	request := httptest.NewRequest(http.MethodPut, "/teammembers", body)
+	tc := getTeamMembersController(request, &data.MockDataAccessor{})
+
+	err := tc.Put()
+	if err == nil {
+		t.Errorf("Expected error: %s", err.Error())
+	}
+}
+
+func TestPutTeamMember_NoName(t *testing.T) {
+	body := getReaderForNewTeamMember("1234", "", "Cabbage Plucker")
+	request := httptest.NewRequest(http.MethodPut, "/teammembers", body)
+	tc := getTeamMembersController(request, &data.MockDataAccessor{})
+
+	err := tc.Put()
+	if err == nil {
+		t.Errorf("Expected error due to empty %q field in TeamMember PUT request.", "name")
+	}
+}
+
+func TestPutTeamMember_NoTitle(t *testing.T) {
+	body := getReaderForNewTeamMember("1234", "Joe Smith", "")
+	request := httptest.NewRequest(http.MethodPut, "/teammembers", body)
+	tc := getTeamMembersController(request, &data.MockDataAccessor{})
+
+	err := tc.Put()
+	if err == nil {
+		t.Errorf("Expected error due to empty %q field in TeamMember PUT request.", "title")
+	}
+}
+
+func TestPutTeamMember_NoTeamMember(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPut, "/teammembers", nil)
+	tc := getTeamMembersController(request, &data.MockDataAccessor{})
+
+	err := tc.Put()
+	if err == nil {
+		t.Errorf("Expected error: %s", err.Error())
+	}
+}
+
+func TestPutTeamMember_Error(t *testing.T) {
+	body := getReaderForNewTeamMember("1234", "Joe Smith", "Cabbage Plucker")
+	request := httptest.NewRequest(http.MethodPut, "/teammembers", body)
+	tc := getTeamMembersController(request, &data.MockErrorDataAccessor{})
+
+	err := tc.Put()
+	if err == nil {
+		t.Errorf("Expected error: %s", err.Error())
+	}
+}
+
 /*
 getTeamMembersController is a helper function for creating and initializing a new BaseController with
 the given HTTP request and DataAccessor. Returns a new TeamMembersController created with that BaseController.

--- a/controller/tmskillscontroller.go
+++ b/controller/tmskillscontroller.go
@@ -143,7 +143,7 @@ func (c *TMSkillsController) removeTMSkill() error {
 		return errors.MissingIDError(fmt.Errorf("no TMSkill ID in request URL"))
 	}
 
-	err := c.session.Delete("tmskills", tmSkillID, data.CassandraQueryOptions{})
+	err := c.session.Delete("tmskills", tmSkillID, data.NewCassandraQueryOptions("team_member_id", "", true))
 	//TODO Add skillid field to opts
 	if err != nil {
 		c.Printf("removeTMSkill() failed for the following reason:\n\t%q\n", err)

--- a/controller/tmskillscontroller.go
+++ b/controller/tmskillscontroller.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"skilldirectory/data"
 	"skilldirectory/errors"
 	"skilldirectory/model"
 	util "skilldirectory/util"
@@ -112,7 +113,7 @@ func (c *TMSkillsController) loadTMSkill(id string) (*model.TMSkill, error) {
 	if err != nil {
 		c.Warnf("loadTMSkill() generated the following error: %v", err)
 		return nil, errors.NoSuchIDError(fmt.Errorf(
-			"No TMSkill Exists with Specified ID: ", id))
+			"No TMSkill Exists with Specified ID: %s ", id))
 	}
 	return &tmSkill, nil
 }
@@ -142,7 +143,8 @@ func (c *TMSkillsController) removeTMSkill() error {
 		return errors.MissingIDError(fmt.Errorf("no TMSkill ID in request URL"))
 	}
 
-	err := c.session.Delete("tmskills", tmSkillID, "team_member_id")
+	err := c.session.Delete("tmskills", tmSkillID, data.CassandraQueryOptions{})
+	//TODO Add skillid field to opts
 	if err != nil {
 		c.Printf("removeTMSkill() failed for the following reason:\n\t%q\n", err)
 		return errors.NoSuchIDError(fmt.Errorf(

--- a/controller/tmskillscontroller.go
+++ b/controller/tmskillscontroller.go
@@ -144,7 +144,7 @@ func (c *TMSkillsController) removeTMSkill() error {
 	}
 
 	err := c.session.Delete("tmskills", tmSkillID, data.NewCassandraQueryOptions("team_member_id", "", true))
-	//TODO Add skillid field to opts
+
 	if err != nil {
 		c.Printf("removeTMSkill() failed for the following reason:\n\t%q\n", err)
 		return errors.NoSuchIDError(fmt.Errorf(

--- a/data/cassandra.go
+++ b/data/cassandra.go
@@ -34,7 +34,7 @@ type Filter struct {
 }
 
 func (f Filter) query() string {
-	queryString := fmt.Sprintf(" %s", f.key)
+	queryString := fmt.Sprintf("%s", f.key)
 	queryString += " = "
 	if !f.id {
 		queryString += "'"
@@ -127,7 +127,7 @@ in the PRIMARY KEY).
 Note that Delete will still be able to execute the DELETE query if "id" is specified as a primary_key_column.
 */
 func (c CassandraConnector) Delete(table, id string, opts CassandraQueryOptions) error {
-	query := queryStringHelper(table, id, opts, c)
+	query := makeDeleteQueryStr(table, id, opts, c)
 	if query == "" {
 		return errors.New("Attempting to delete with no id")
 	}
@@ -135,7 +135,7 @@ func (c CassandraConnector) Delete(table, id string, opts CassandraQueryOptions)
 	return c.Query(query).Exec()
 }
 
-func queryStringHelper(table string, id string, opts CassandraQueryOptions, c CassandraConnector) string {
+func makeDeleteQueryStr(table string, id string, opts CassandraQueryOptions, c CassandraConnector) string {
 	query := "DELETE FROM " + table + " WHERE " // Base query
 	c.Infof("Deleting:%s,%s,%v", table, id, opts)
 	firstField := true

--- a/data/cassandra_test.go
+++ b/data/cassandra_test.go
@@ -40,3 +40,15 @@ func TestNewOptions(t *testing.T) {
 		t.Error("Expecting AddFilter to match")
 	}
 }
+
+func TestDeleteSkillChildrean(t *testing.T) {
+	table := "links"
+	id := ""
+	skillID := "1234"
+	opts := NewCassandraQueryOptions("skill_ID", skillID, true)
+	valid := "DELETE FROM links WHERE skill_ID = 1234;"
+	queryString := queryStringHelper(table, id, opts, CassandraConnector{})
+	if valid != queryString {
+		t.Errorf("Excpecting quesryString to match: %s, %s ", valid, queryString)
+	}
+}

--- a/data/dataaccess.go
+++ b/data/dataaccess.go
@@ -12,7 +12,7 @@ type DataAccess interface {
 	ReadAll(table string, readType ReadAllInterface) ([]interface{}, error)
 	FilteredReadAll(table string, opts CassandraQueryOptions,
 		readType ReadAllInterface) ([]interface{}, error)
-	Delete(table, id string, primary_key_cols ...string) error
+	Delete(table, id string, opts CassandraQueryOptions) error
 }
 
 /*

--- a/data/mock.go
+++ b/data/mock.go
@@ -8,7 +8,7 @@ type MockDataAccessor struct{}
 
 func (m MockDataAccessor) Save(t, s string, i interface{}) error                     { return nil }
 func (m MockDataAccessor) Read(t, s string, i interface{}) error                     { return nil }
-func (c MockDataAccessor) Delete(table, id string, primary_key_cols ...string) error { return nil }
+func (c MockDataAccessor) Delete(table, id string, opts CassandraQueryOptions) error { return nil }
 func (m MockDataAccessor) ReadAll(t string, r ReadAllInterface) ([]interface{}, error) {
 	return nil, nil
 }
@@ -20,7 +20,7 @@ type MockErrorDataAccessor struct{}
 
 func (e MockErrorDataAccessor) Save(t, s string, i interface{}) error { return fmt.Errorf("") }
 func (e MockErrorDataAccessor) Read(t, s string, i interface{}) error { return fmt.Errorf("") }
-func (c MockErrorDataAccessor) Delete(table, id string, primary_key_cols ...string) error {
+func (c MockErrorDataAccessor) Delete(table, id string, opts CassandraQueryOptions) error {
 	return fmt.Errorf("")
 }
 func (e MockErrorDataAccessor) ReadAll(t string, r ReadAllInterface) ([]interface{}, error) {


### PR DESCRIPTION
Also refactor cassandra.go delete method to accept a `CassandraQueryOptions` parameter.
Fixes #146 