### PR TITLE
Addition of API Testing Docker Image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ test:
 
 deployment:
   master:
-    branch: master
+    branch: [master, automate-api-tests187]
     commands:
       - echo $CIRCLE_BRANCH
       - docker login -u "$DOCKER_USER" -p "$dockerPass" --email "$DOCKER_EMAIL"

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,7 @@ deployment:
       - cd ${GOPATH}/src/${IMPORT_PATH} && export DEBUG_FLAG=false && docker build -t $DOCKER_IMAGE:$CIRCLE_TAG .
       - docker push $DOCKER_IMAGE:$CIRCLE_TAG
   master:
-    branch: [master, automate-api-tests187]
+    branch: master    
     commands:
       - docker login -u "$DOCKER_USER" -p "$dockerPass" --email "$DOCKER_EMAIL"
       - cd ${GOPATH}/src/${IMPORT_PATH} && export DEBUG_FLAG=false && docker build -t $IMAGE:$CIRCLE_BRANCH .

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,6 @@
 machine:
-
   services:
     - docker
-
   environment:
     GODIST: "go1.7.3.linux-amd64.tar.gz"
     IMPORT_PATH: "$CIRCLE_PROJECT_REPONAME"
@@ -10,15 +8,14 @@ machine:
     GOPATH: /home/ubuntu/.go_workspace
     DOCKER_USER: thebho
     DOCKER_EMAIL: brian.hoehne@maryville.com
-    DOCKER_IMAGE: maryville/skilldirectory
-
+    IMAGE: maryville/skilldirectory
+    TESTER_IMAGE: maryville/skilldirectory-tester
 
   post:
     - mkdir -p download
     - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
     - sudo rm -rf /usr/local/go
     - sudo tar -C /usr/local -xzf download/$GODIST
-
 
 dependencies:
   override:
@@ -42,6 +39,8 @@ deployment:
     commands:
       - echo $CIRCLE_BRANCH
       - docker login -u "$DOCKER_USER" -p "$dockerPass" --email "$DOCKER_EMAIL"
-      - cd ${GOPATH}/src/${IMPORT_PATH} && export DEBUG_FLAG=false && docker build -t $DOCKER_IMAGE:$CIRCLE_BRANCH .
+      - cd ${GOPATH}/src/${IMPORT_PATH} && export DEBUG_FLAG=false && docker build -t $IMAGE:$CIRCLE_BRANCH .
+      - cd postman && docker build -t $TESTER_IMAGE:$CIRCLE_BRANCH .
       - docker images
-      - docker push $DOCKER_IMAGE:$CIRCLE_BRANCH
+      - docker push $IMAGE:$CIRCLE_BRANCH
+      - docker push $TESTER_IMAGE:$CIRCLE_BRANCH

--- a/postman/Dockerfile
+++ b/postman/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:alpine
+RUN apk update
+RUN apk add bash curl
+RUN npm install -g newman
+ADD * /postman/
+RUN ls /postman
+ENTRYPOINT ["/bin/bash", "-c", "cd /postman && /postman/test-reporter"]

--- a/postman/test
+++ b/postman/test
@@ -24,14 +24,14 @@ COLOR='\033[0;36m' # Cyan
 
 # Process all command line flags
 VALID_OPTIONS="Valid options are: 
-  --verbose (turns on verbose output)
-  --200     (runs 200 suite of tests)
-  --400     (runs 400 suite of tests)
-  --file    (runs FILE suite of tests)
-  --export  (saves JSON file of environment after completion of specified suites)
-  --api-url=<URL to API> (sets the URL to hit when running tests)
-  --all     (runs all suites of tests; 200, 400, and FILE)
-  --help    (displays list of valid options)\n"
+  --verbose  (turns on verbose output)
+  --200      (runs 200 suite of tests)
+  --400      (runs 400 suite of tests)
+  --file     (runs FILE suite of tests)
+  --export   (saves JSON file of environment after completion of specified suites)
+  --api-url= (sets the URL to hit when running tests)
+  --all      (runs all suites of tests; 200, 400, and FILE)
+  --help     (displays list of valid options)\n"
 for arg in "$@"
 do
 case $arg in
@@ -99,7 +99,7 @@ echo "$ENV_JSON" > $ENV_FILE
 OPTIONS="-e $ENV_FILE $VERBOSITY --export-environment $ENV_FILE"
 EXIT_STATUS=0
 if $RUN_200; then
-  printf "${COLOR}<<<<< Running 200 Suite... >>>>>\n"
+  printf "${COLOR}<<<<< Running 200 Suite... >>>>>"
   newman run skilldirectory-200.json $OPTIONS  
   if [[ $EXIT_STATUS == 1 || $? == 1 ]]; then
     EXIT_STATUS=1
@@ -107,7 +107,7 @@ if $RUN_200; then
   printf "${COLOR}<<<<< Done with 200 Suite. >>>>>\n"
 fi
 if $RUN_400; then
-  printf "${COLOR}<<<<< Running 400 Suite... >>>>>\n"
+  printf "${COLOR}<<<<< Running 400 Suite... >>>>>"
   newman run skilldirectory-400.json $OPTIONS
   if [[ $EXIT_STATUS == 1 || $? == 1 ]]; then
     EXIT_STATUS=1
@@ -115,7 +115,7 @@ if $RUN_400; then
   printf "${COLOR}<<<<< Done with 400 Suite. >>>>>\n"
 fi
 if $RUN_FILE; then
-  printf "${COLOR}<<<<< Running FILE Suite... >>>>>\n"
+  printf "${COLOR}<<<<< Running FILE Suite... >>>>>"
   newman run skilldirectory-file.json $OPTIONS  
   if [[ $EXIT_STATUS == 1 || $? == 1 ]]; then
     EXIT_STATUS=1

--- a/postman/test-reporter
+++ b/postman/test-reporter
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+################################################################################
+# This script is used to run the test script, and report the results to Slack. #
+# Relies on existence of three environment variables:                          #
+#  * API         - should hold URL for tests to hit                            #
+#  * SLACK_HOOK  - should hold URL to send results to                          #
+#  * SLACK_TOKEN - should hold token allow script to post file to Slack        #
+################################################################################
+
+# Run tests & store results
+printf "Running tests...\n"
+RESULTS="$(./test --all --verbose --api-url=$API)"
+EXIT_CODE=$?
+printf "Done running tests.\n"
+
+# Post results as file to Slack
+MULTIPART_RESPONSE=$( \
+curl \
+  --form "token=$SLACK_TOKEN" \
+  --form "filetype=txt" \
+  --form "filename=test-results.txt" \
+  --form "title=Postman Test Results" \
+  --form "channels=#skilldirectory-bots" \
+  --form "file=@test-results.txt" \
+  https://slack.com/api/files.upload)
+
+# Extract file URL from POST response
+FILE_URL=$(
+echo $MULTIPART_RESPONSE | # From response
+grep -o '"permalink":".*test-results.txt"' | # extract json "key":"value", then
+grep -o 'https:.*test-results.txt' | # extract value (a file url), then
+sed "s/[\\]//g") # strip out escape backslashes.
+
+# Post message with test results file URL to Slack channel
+printf "Sending results to Slack...\n"
+if [[ $EXIT_CODE == 0 ]]; then
+  TEXT='*Postman API Tests Passed!*'
+  COLOR='3EB890'
+else
+  TEXT='*Postman API Tests Failed*'
+  COLOR='E01765'
+fi
+
+PAYLOAD=\
+'{
+  "channel": "#skilldirectory-bots", 
+  "username": "SkillDirectory Bot", 
+  "text": "'$TEXT'",
+  "attachments": [
+    {
+      "text": "Test Results:\n'$FILE_URL'",
+      "color": "'$COLOR'"
+    }
+  ]
+}' 
+
+curl -X POST -H 'Content-type: application/json' \
+--data "$PAYLOAD" $SLACK_HOOK
+printf "\nDone sending results to Slack...\n"


### PR DESCRIPTION
Fixes #187. This PR causes CircleCI to build and push a new Docker image to the Docker Hub: `skilldirectory-tester`. When this image is run, it runs the API tests, submits the results to the Slack channel, and exits. This image is lightweight and based on `node:alpine`. The image simply runs the `postman/test-reporter` script on startup. 

The `postman/test-reporter` script (and thus, the `skilldirectory-tester` image) relies on the existence of three environment variables to succeed:

* API         - should hold URL for tests to hit                           
* SLACK_HOOK  - should hold URL to send results to                        
* SLACK_TOKEN - should hold token to allow script to post file to Slack   